### PR TITLE
Update options.class.php

### DIFF
--- a/classes/options.class.php
+++ b/classes/options.class.php
@@ -153,6 +153,10 @@ abstract class CSFramework_Options extends CSFramework_Abstract {
       $out .= "<strong>". __( 'USAGE', 'cs-framework' ) .":</strong>";
       $out .= "\n";
       $out .= ( isset( $this->field['id'] ) ) ? "cs_get_option( '". $this->field['id'] ."' );" : '';
+      $out .= "\n";
+      $out .= "<strong>". __( 'ID', 'cs-framework' ) .":</strong>";
+      $out .= "\n";
+      $out .= ( isset( $this->field['id'] ) ) ? "". $this->field['id'] ."" : '';
       $out .= "</pre>";
 
     }


### PR DESCRIPTION
Updated Debug Light to include ID only below Usage info. 

So now Debug Light shows.. 

USAGE: 
`cs-get_option('field_id');`
ID:
`field_id`

**New screenshot @ http://take.ms/ky2Nl**

![image](https://cloud.githubusercontent.com/assets/6123260/14435020/cb413d54-ffe3-11e5-9207-15a9f5c1238e.png)

**Compare to old screenshot @ http://take.ms/nYabW**

![image](https://cloud.githubusercontent.com/assets/6123260/14435049/ebf4fd06-ffe3-11e5-9a28-df03bc3c3bb4.png)